### PR TITLE
Fixed signature spec issue

### DIFF
--- a/AzureHSMService.cs
+++ b/AzureHSMService.cs
@@ -16,9 +16,9 @@ namespace azure_hsm_signing {
     public AzureHSMService()
     {
       // The URL that the KeyVault is hosted at on Azure
-      const string hsmUrl = "https://pdftron-hsm-digsigs.vault.azure.net/";
+      const string hsmUrl = "https://apryse.vault.azure.net/";
       // The name of the non-exportable Certificate under the KeyVault named pdftron-hsm-digsigs
-      const string certificateName = "hsm-test";
+      const string certificateName = "Pdftron";
 
       KeyClient keyClient = new KeyClient(new Uri(hsmUrl), new VisualStudioCredential());
       CertificateClient certificateClient = new CertificateClient(new Uri(hsmUrl), new VisualStudioCredential());

--- a/PDFNetWrapper.cs
+++ b/PDFNetWrapper.cs
@@ -16,18 +16,16 @@ namespace azure_hsm_signing
     }
     public PDFDoc PreparePdfForCustomSigning(PDFDoc doc, string signatureFieldName, uint sizeOfContents = 7500)
     {
-      Page page1 = doc.GetPage(1);
       Field found_approval_field = doc.GetField(signatureFieldName);
       bool isLockedByDigitalSignature = found_approval_field != null && found_approval_field.IsLockedByDigitalSignature();
+
       if (isLockedByDigitalSignature)
       {
         throw new Exception($"The field {signatureFieldName} is locked by a Digital Signature, and thus cannot be Digitally Signed again");
       }
 
-      certification_sig_field = doc.CreateDigitalSignatureField(signatureFieldName);
-      SignatureWidget widgetAnnot = SignatureWidget.Create(doc, new Rect(), certification_sig_field);
+      certification_sig_field = new DigitalSignatureField(found_approval_field);
 
-      page1.AnnotPushBack(widgetAnnot);
       certification_sig_field.SetDocumentPermissions(DigitalSignatureField.DocumentPermissions.e_no_changes_allowed);
 
       // Prepare the signature and signature handler for signing.
@@ -55,7 +53,8 @@ namespace azure_hsm_signing
 
     public void SavePdfWithDigitalSignature(PDFDoc doc, string signatureFieldName, byte[] pkcs7message, string pdfDirectory, string nameOfFile)
     {
-      DigitalSignatureField certification_sig_field = doc.CreateDigitalSignatureField(signatureFieldName);
+      Field certification_field = doc.GetField(signatureFieldName);
+      DigitalSignatureField certification_sig_field = new DigitalSignatureField(certification_field);
       doc.SaveCustomSignature(
         pkcs7message,
         certification_sig_field,

--- a/Program.cs
+++ b/Program.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 
 using pdftron.Crypto;
 using pdftron.PDF;
@@ -50,7 +51,7 @@ namespace azure_hsm_signing
       int[] digest_alg_oid_nums = new int[] { 2, 16, 840, 1, 101, 3, 4, 2, 1 }; // sha-256
       ObjectIdentifier digest_algorithm_oid = new ObjectIdentifier(digest_alg_oid_nums);
       // Use appropriate signature algorithm OID
-      // const UInt32 sig_alg_oid_nums[] = new UInt32[]{ 1, 2, 840, 113549, 1, 1, 1 }; // rsaEncryption
+      //int[] sig_alg_oid_nums = new int[]{ 1, 2, 840, 113549, 1, 1, 1 }; // rsaEncryption
       int[] sig_alg_oid_nums = new int[] { 1, 2, 840, 113549, 1, 1, 11 }; // sha256WithRSAEncryption
       ObjectIdentifier signature_algorithm_oid = new ObjectIdentifier(sig_alg_oid_nums);
 

--- a/azure-hsm-signing.csproj
+++ b/azure-hsm-signing.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <RootNamespace>azure_hsm_signing</RootNamespace>


### PR DESCRIPTION
Fixed the issue where the signature has a Kids key which is unexpected for a signature.
![image](https://github.com/CorreyL/azure-hsm-signing/assets/32521239/c314af90-ae26-460c-8fae-919cdb7b5f38)
